### PR TITLE
remove arm

### DIFF
--- a/.github/workflows/ffi-builds.yml
+++ b/.github/workflows/ffi-builds.yml
@@ -52,48 +52,12 @@ jobs:
             target: aarch64-apple-darwin
             macosx_deployment_target: "11.0" # aarch64 requires 11
             name: ffi-macos-arm64
-          - os: macos-13
-            platform: ios
-            dylib: liblivekit_ffi.a
-            target: aarch64-apple-ios
-            iphoneos_deployment_target: "13.0"
-            name: ffi-ios-arm64
-            buildargs: --no-default-features --features "rustls-tls-webpki-roots"
-          - os: macos-13
-            platform: ios
-            dylib: liblivekit_ffi.a
-            target: aarch64-apple-ios-sim
-            iphoneos_deployment_target: "13.0"
-            name: ffi-ios-sim-arm64
-            buildargs: --no-default-features --features "rustls-tls-webpki-roots"
           - os: ubuntu-20.04
             platform: linux
             build_image: quay.io/pypa/manylinux_2_28_x86_64
             dylib: liblivekit_ffi.so
             target: x86_64-unknown-linux-gnu
             name: ffi-linux-x86_64
-          - os: buildjet-4vcpu-ubuntu-2204-arm
-            platform: linux
-            build_image: quay.io/pypa/manylinux_2_28_aarch64
-            dylib: liblivekit_ffi.so
-            target: aarch64-unknown-linux-gnu
-            name: ffi-linux-arm64
-          - os: ubuntu-20.04
-            platform: android
-            dylib: liblivekit_ffi.so
-            jar: libwebrtc.jar
-            target: aarch64-linux-android
-            ndk_arch: aarch64-unknown-linux-musl
-            name: ffi-android-arm64
-            buildargs: --no-default-features --features "rustls-tls-webpki-roots"
-          - os: ubuntu-20.04
-            platform: android
-            dylib: liblivekit_ffi.so
-            jar: libwebrtc.jar
-            target: armv7-linux-androideabi
-            ndk_arch: arm-unknown-linux-musleabihf
-            name: ffi-android-armv7
-            buildargs: --no-default-features --features "rustls-tls-webpki-roots"
           - os: ubuntu-20.04
             platform: android
             dylib: liblivekit_ffi.so

--- a/.github/workflows/webrtc-builds.yml
+++ b/.github/workflows/webrtc-builds.yml
@@ -30,58 +30,22 @@ jobs:
             cmd: .\build_windows.cmd
             arch: x64
 
-          - name: win
-            os: windows-2019
-            cmd: .\build_windows.cmd
-            arch: arm64
-
           - name: mac
             os: macos-13
             cmd: ./build_macos.sh
             arch: x64
-
-          - name: mac
-            os: macos-13
-            cmd: ./build_macos.sh
-            arch: arm64
 
           - name: linux
             os: buildjet-8vcpu-ubuntu-2004
             cmd: ./build_linux.sh
             arch: x64
 
-          - name: linux
-            os: buildjet-8vcpu-ubuntu-2004
-            cmd: ./build_linux.sh
-            arch: arm64
-
-          - name: android
-            os: buildjet-8vcpu-ubuntu-2004
-            cmd: ./build_android.sh
-            arch: arm64
-
-          - name: android
-            os: buildjet-8vcpu-ubuntu-2004
-            cmd: ./build_android.sh
-            arch: arm
-
           - name: android
             os: buildjet-8vcpu-ubuntu-2004
             cmd: ./build_android.sh
             arch: x64
 
-          - name: ios
-            out: ios-device-arm64
-            os: macos-13
-            cmd: ./build_ios.sh
-            arch: arm64
 
-          - name: ios
-            out: ios-simulator-arm64
-            os: macos-13
-            cmd: ./build_ios.sh
-            arch: arm64
-            buildargs: --environment simulator
         profile:
           - release
     #          - debug


### PR DESCRIPTION
This pull request removes several build configurations from the GitHub workflows for `ffi-builds` and `webrtc-builds`. The most important changes are the removal of various platform-specific build targets, including iOS, Android, and ARM architectures for macOS, Linux, and Windows.

Changes to GitHub workflows:

* [`.github/workflows/ffi-builds.yml`](diffhunk://#diff-ae1cdcd2f6adff478f6ad2f3e3c486d42c5fbd365247019f1979c44abfeae97aL55-L96): Removed build configurations for iOS (both device and simulator), Android (both ARM64 and ARMv7), and Linux ARM64 platforms.
* [`.github/workflows/webrtc-builds.yml`](diffhunk://#diff-55b79a057d0da2f8c930e38fb2aa894e572eb10b99981b48b3905ae530a0975eL33-L84): Removed build configurations for Windows ARM64, macOS ARM64, Linux ARM64, Android (both ARM64 and ARM), and iOS (both device and simulator) platforms.