### PR TITLE
configure crates to publish to Quantum Forge registry

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[registries.quantum-forge]
+index = "https://crate-registry.quantum-forge.io"
+
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+  CARGO_REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
 
 jobs:
   bump:
@@ -48,10 +48,15 @@ jobs:
       - name: Resync is needed after bump
         run: |
           git fetch --tags && git checkout origin/main
+      - name: Configure Cargo Registry
+        run: |
+          mkdir -p ~/.cargo
+          echo '[registries.quantum-forge]' >> ~/.cargo/config.toml
+          echo 'index = "https://crate-registry.quantum-forge.io"' >> ~/.cargo/config.toml
       - name: Publish crates
         run: |
           git tag --points-at HEAD |
           sed 's|^[^/]*@|@|' |
           sed 's|^[^/]*/||' |
           sed 's|@.*||' |
-          xargs -I _ sh -c 'cd ./_ && cargo publish --no-verify'
+          xargs -I _ sh -c 'cd ./_ && cargo publish --no-verify --registry quantum-forge'

--- a/.nanpa/new-crate-registry.kdl
+++ b/.nanpa/new-crate-registry.kdl
@@ -1,0 +1,1 @@
+minor type="changed" "Configure crates to publish to Quantum Forge registry"


### PR DESCRIPTION
This pull request includes changes to configure the project to publish crates to the Quantum Forge registry. The most important changes involve updating the Cargo configuration and modifying the GitHub Actions workflow for publishing.

Changes to Cargo configuration:

* [`.cargo/config.toml`](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R1-R3): Added a new registry configuration for Quantum Forge.

Updates to GitHub Actions workflow:

* `.github/workflows/publish.yml`: 
  * Changed the environment variable `CARGO_REGISTRY_TOKEN` to use `REGISTRY_TOKEN` instead.
  * Added a step to configure the Cargo registry before publishing crates.
  * Updated the `cargo publish` command to use the Quantum Forge registry.

Documentation update:

* [`.nanpa/new-crate-registry.kdl`](diffhunk://#diff-9f349d59bbc7cec2b78e071446d95c79c4f097fe62ccaefc7d49cb1fdf4fff3fR1): Added a minor type change entry to document the configuration for publishing to Quantum Forge.