### PR TITLE
Refactor publish workflow to remove manual package input and add buil…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,6 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
-    inputs:
-      packages:
-        description: "packages to bump (comma-separated list)"
-        type: string
-        required: true
   pull_request:
     types: [closed]
     branches: ["main"]
@@ -32,40 +27,118 @@ env:
   CARGO_REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
 
 jobs:
+  # Wait for the builds workflow to complete
+  wait-for-builds:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Wait for builds to complete
+        run: |
+          echo "Waiting for builds to complete..."
+          # Using GitHub API to check if builds workflow was successful
+          OWNER=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 1)
+          REPO=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)
+          COMMIT_SHA=$GITHUB_SHA
+          
+          # Wait for builds workflow to complete
+          for i in {1..10}; do
+            echo "Checking build status (attempt $i)..."
+            STATUS=$(gh api repos/$OWNER/$REPO/commits/$COMMIT_SHA/check-runs --jq '.check_runs[] | select(.name | contains("Build (")) | .conclusion')
+            
+            # If we have success statuses for all builds, proceed
+            if [[ $(echo "$STATUS" | grep -c "success") -gt 0 ]]; then
+              echo "Builds completed successfully!"
+              exit 0
+            fi
+            
+            # If we have any failure statuses, fail
+            if [[ $(echo "$STATUS" | grep -c "failure") -gt 0 ]]; then
+              echo "Builds failed!"
+              exit 1
+            fi
+            
+            echo "Builds still running, waiting 30 seconds..."
+            sleep 30
+          done
+          
+          echo "Timed out waiting for builds to complete"
+          exit 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   bump:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    needs: wait-for-builds
     steps:
       - uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.NANPA_KEY }}
+          
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
         
-      - name: Prepare packages for ilo
-        id: prepare_packages
+      - name: Determine packages to bump
+        id: determine_packages
         run: |
-          # Check if this is a manual workflow run or push trigger
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Create an array from comma-separated list provided by user
-            IFS=',' read -ra PKG_ARRAY <<< "${{ github.event.inputs.packages }}"
-            
-            # Convert to JSON format with explicit wrapping
-            JSON_ARRAY=$(printf '%s\n' "${PKG_ARRAY[@]}" | jq -R . | jq -s .)
-            echo "Workflow dispatch with packages: ${PKG_ARRAY[*]}"
+          # For workflow_dispatch, use the provided packages if any
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.packages }}" ]]; then
+            PACKAGES="${{ github.event.inputs.packages }}"
+            echo "Using manually specified packages: $PACKAGES"
           else
-            # For push events, use an empty array (no packages to bump)
-            # This effectively makes the workflow run but not perform any version bumps
+            # For push events, determine packages based on changed files
+            echo "Determining packages to bump based on changed files..."
+            
+            # Get list of changed files
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD || git diff --name-only $(git rev-list --max-parents=0 HEAD) HEAD)
+            
+            # Extract package directories from .nanparc
+            if [ -f ".nanparc" ]; then
+              PACKAGE_DIRS=$(grep -v '^#' .nanparc | grep "^packages" | cut -d ' ' -f 2-)
+              
+              # Initialize an empty array for packages to bump
+              PACKAGES_TO_BUMP=()
+              
+              # For each package directory, check if any files have changed
+              for PKG in $PACKAGE_DIRS; do
+                if echo "$CHANGED_FILES" | grep -q "^$PKG/"; then
+                  PACKAGES_TO_BUMP+=("$PKG")
+                fi
+              done
+              
+              # Join the packages with commas
+              PACKAGES=$(IFS=,; echo "${PACKAGES_TO_BUMP[*]}")
+              
+              if [ -n "$PACKAGES" ]; then
+                echo "Detected changes in packages: $PACKAGES"
+              else
+                echo "No changes detected in tracked packages."
+                PACKAGES=""
+              fi
+            else
+              echo "No .nanparc file found, unable to determine packages."
+              PACKAGES=""
+            fi
+          fi
+          
+          # Save packages for later steps
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+          
+          # Create JSON array for ilo
+          if [ -n "$PACKAGES" ]; then
+            IFS=',' read -ra PKG_ARRAY <<< "$PACKAGES"
+            JSON_ARRAY=$(printf '%s\n' "${PKG_ARRAY[@]}" | jq -R . | jq -s .)
+          else
             JSON_ARRAY="[]"
-            echo "Push trigger - using empty package list"
           fi
           
           echo "Formatted packages JSON: $JSON_ARRAY"
-          
-          # Save to a file that ilo can read - ensure we preserve quotes and formatting
           echo "$JSON_ARRAY" > packages.json
-          
+
       - name: Debug packages.json content
         run: |
           echo "Raw file content:"
@@ -73,10 +146,12 @@ jobs:
           echo "JSON validation check:"
           jq '.' packages.json || echo "Invalid JSON detected"
           
-      - name: Use ilo with packages file
+      - name: Use ilo to bump package versions
+        if: steps.determine_packages.outputs.packages != ''
         uses: nbsp/ilo@v1
         with:
-          packages: '[]'
+          packages: ${{ steps.determine_packages.outputs.packages }}
+
   publish:
     runs-on: ubuntu-latest
     needs: bump
@@ -88,9 +163,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          
       - name: Resync is needed after bump
         run: |
           git fetch --tags && git checkout origin/main
+          
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
This pull request includes significant updates to the `.github/workflows/publish.yml` file to enhance the automation process for publishing packages. The key changes involve removing manual input requirements, adding a job to wait for builds to complete, and dynamically determining which packages need to be bumped based on changed files.

### Workflow automation improvements:

* Removed the manual input requirement for specifying packages to bump during `workflow_dispatch` events.
* Added a new job `wait-for-builds` that ensures all builds are completed successfully before proceeding with the bump job. This job uses the GitHub API to check the status of builds and waits until they are finished.
* Modified the `bump` job to dynamically determine which packages need to be bumped based on the files changed in the latest commit. This logic handles both `workflow_dispatch` and `push` events.
* Updated the `bump` job to use the dynamically determined list of packages when calling the `ilo` action for version bumping.
* Ensured that the `publish` job, which runs after the `bump` job, includes necessary steps such as checking out the repository with submodules and installing the Rust toolchain.…d completion check