### PR TITLE
Remove git-fetch-with-cli configuration from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -184,7 +184,6 @@ jobs:
           index = "https://crate-registry.quantum-forge.io"
           
           [net]
-          git-fetch-with-cli = true
           retry = 5
           
           [http]


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change removes the `git-fetch-with-cli` setting from the `[net]` section, which simplifies the configuration.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L187): Removed the `git-fetch-with-cli` setting from the `[net]` section.