### PR TITLE
Update cargo registry index URL to use API version in configuration

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [registries.quantum-forge]
-index = "https://crate-registry.quantum-forge.io"
+index = "https://crate-registry.quantum-forge.io/api/v1/crates/"
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,7 +181,7 @@ jobs:
           # Create main config file
           cat > ~/.cargo/config.toml << EOF
           [registries.quantum-forge]
-          index = "sparse+https://crate-registry.quantum-forge.io"
+          index = "sparse+https://crate-registry.quantum-forge.io/api/v1/crates/"
           
           [net]
           retry = 5


### PR DESCRIPTION
This pull request includes changes to update the registry index URL for Quantum Forge in the configuration files. The changes ensure that the correct API endpoint is used.

Configuration updates:

* [`.cargo/config.toml`](diffhunk://#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268L2-R2): Updated the `index` URL for the `quantum-forge` registry to include the `/api/v1/crates/` path.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L184-R184): Updated the `index` URL for the `quantum-forge` registry in the workflow configuration to include the `/api/v1/crates/` path.